### PR TITLE
Update larastan level to max.

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,6 @@
 includes:
   - vendor/nunomaduro/larastan/extension.neon
 parameters:
-  level: 8
+  level: max
   paths:
     - src

--- a/src/Analyzer/Query.php
+++ b/src/Analyzer/Query.php
@@ -19,10 +19,10 @@ class Query
     private $buildedQuery;
 
     /**
-     * @param string          $query
+     * @param string $query
      * @param array<int|string, int|string>|array{} $bindings
-     * @param float           $time
-     * @param string          $buildedQuery
+     * @param float  $time
+     * @param string $buildedQuery
      */
     public function __construct(
         string $query,

--- a/src/Analyzer/Query.php
+++ b/src/Analyzer/Query.php
@@ -9,7 +9,7 @@ class Query
     /** @var string */
     private $query;
 
-    /** @var array<int, int> */
+    /** @var array<int|string, int|string>|array{} */
     private $bindings;
 
     /** @var float */
@@ -20,7 +20,7 @@ class Query
 
     /**
      * @param string          $query
-     * @param array<int, int> $bindings
+     * @param array<int|string, int|string>|array{} $bindings
      * @param float           $time
      * @param string          $buildedQuery
      */
@@ -42,7 +42,7 @@ class Query
     }
 
     /**
-     * @return array<int, int>
+     * @return array<int|string, int|string>|array{}
      */
     public function getBindings(): array
     {

--- a/src/Helper/QueryLog.php
+++ b/src/Helper/QueryLog.php
@@ -23,7 +23,11 @@ class QueryLog
      *
      * @param callable $queryCaller
      *
-     * @return array<int, array{"query": string, "bindings": array<int, mixed>, "time": float}>
+     * @return array<int, array{
+     *      "query": string,
+     *      "bindings": array<int|string, int|string>|array{},
+     *      "time": float
+     * }>
      */
     public function getQueryLog(callable $queryCaller): array
     {


### PR DESCRIPTION
The following rule violations that occurred when max level was reached have been fixed.

```sh
------ ------------------------------------------------------------------------- 
  Line   Analyzer/QueryAnalyzer.php                                               
 ------ ------------------------------------------------------------------------- 
  22     Parameter #2 $bindings of class Laqu\Analyzer\Query constructor expects  
         array<int, int>, array<int, mixed> given.                                
 ------ -------------------------------------------------------------------------
```

I was told to return `array<int, int>` for larastan, but since there was a possibility that a string would be returned for each key and value, I used `array<int|string, int|string>`.
Also, there was a possibility that an empty array `array{}` would be returned, so I added that as well.